### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/src/org/ramadda/plugins/biblio/BiblioTypeHandler.java
+++ b/src/org/ramadda/plugins/biblio/BiblioTypeHandler.java
@@ -199,7 +199,7 @@ public class BiblioTypeHandler extends GenericTypeHandler {
             if (doi != null) {
                 sb.append(" doi: ");
                 if ( !doi.startsWith("http")) {
-                    doi = "http://dx.doi.org/" + doi;
+                    doi = "https://doi.org/" + doi;
                 }
                 sb.append(HtmlUtils.href(doi, doi));
             }

--- a/src/org/ramadda/plugins/doi/DoiMetadataHandler.java
+++ b/src/org/ramadda/plugins/doi/DoiMetadataHandler.java
@@ -134,7 +134,7 @@ public class DoiMetadataHandler extends MetadataHandler {
 
     //http://n2t.net/ark:/99999/fk47h23wj
     //ark:/99999/fk47h23wj
-    //http://dx.doi.org/
+    //https://doi.org/
 
     /**
      * _more_
@@ -145,7 +145,7 @@ public class DoiMetadataHandler extends MetadataHandler {
      */
     public static String getUrl(String id) {
         if (id.startsWith("doi:")) {
-            return id.replace("doi:", "http://dx.doi.org/");
+            return id.replace("doi:", "https://doi.org/");
         }
 
         return id.replace("ark:", "http://n2t.net/ark:");


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected, there is no urgency here.

I'd simply like to suggest to update all code that generates new DOI links accordingly.

Cheers!